### PR TITLE
Fix NED/ENU angle conversion issues 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,9 @@ target_link_libraries(sbg_device_mag ${catkin_LIBRARIES} sbgECom)
 ament_target_dependencies(sbg_device ${USED_LIBRARIES}) 
 ament_target_dependencies(sbg_device_mag ${USED_LIBRARIES})
 
-rosidl_target_interfaces(sbg_device ${PROJECT_NAME} "rosidl_typesupport_cpp")
-rosidl_target_interfaces(sbg_device_mag ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+target_link_libraries(sbg_device "${cpp_typesupport_target}")
+target_link_libraries(sbg_device_mag "${cpp_typesupport_target}")
 
 set_property(TARGET sbg_device PROPERTY CXX_STANDARD 14)
 set_property(TARGET sbg_device_mag PROPERTY CXX_STANDARD 14)

--- a/include/sbg_driver/message_wrapper.h
+++ b/include/sbg_driver/message_wrapper.h
@@ -111,6 +111,14 @@ private:
   //---------------------------------------------------------------------//
 
   /*!
+   * Wrap an angle to PI.
+   *
+   * \param[in] angle_rad			Angle in rad.
+   * \return						Wrapped angle.
+   */
+  float wrapAnglePi(float angle_rad) const;
+
+  /*!
    * Wrap an angle to 2 PI.
    *
    * \param[in] angle_rad			Angle in rad.


### PR DESCRIPTION
- Implemented a method to wrap between -Pi and Pi
- Changed the euler angle ENU conversion to wrap the yaw to Pi, instead of the original (2 Pi)
- Refactored the quaternion conversion to convert to euler,  apply the correct operation to transform to ENU, then convert back to NED

I had a look at several ways to do the quaternion ENU conversion, but this is the only one I could get to work properly without spending significantly longer on this task.  